### PR TITLE
Fix "unexpected keyword argument 'batch_id'"

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 stevedore
-celery
+celery<4.0
 click>=4.0
 lxml
 redis


### PR DESCRIPTION
With celery 4.0 param filtering used in NidabaTask is not applied. It leads to the following stacktrace:
```
2016-12-02T12:27:11.184726235Z Traceback (most recent call last):
2016-12-02T12:27:11.184773306Z   File "/usr/local/bin/nidaba", line 10, in <module>
2016-12-02T12:27:11.184826303Z     sys.exit(main())
2016-12-02T12:27:11.184852470Z   File "/usr/local/lib/python2.7/dist-packages/click/core.py", line 716, in __call__
2016-12-02T12:27:11.185492937Z     return self.main(*args, **kwargs)
2016-12-02T12:27:11.185532771Z   File "/usr/local/lib/python2.7/dist-packages/click/core.py", line 696, in main
2016-12-02T12:27:11.185715630Z     rv = self.invoke(ctx)
2016-12-02T12:27:11.185745626Z   File "/usr/local/lib/python2.7/dist-packages/click/core.py", line 1060, in invoke
2016-12-02T12:27:11.185919659Z     return _process_result(sub_ctx.command.invoke(sub_ctx))
2016-12-02T12:27:11.185946717Z   File "/usr/local/lib/python2.7/dist-packages/click/core.py", line 889, in invoke
2016-12-02T12:27:11.186138560Z     return ctx.invoke(self.callback, **ctx.params)
2016-12-02T12:27:11.186173047Z   File "/usr/local/lib/python2.7/dist-packages/click/core.py", line 534, in invoke
2016-12-02T12:27:11.186297133Z     return callback(*args, **kwargs)
2016-12-02T12:27:11.186331064Z   File "/usr/local/lib/python2.7/dist-packages/nidaba/cli.py", line 275, in batch
2016-12-02T12:27:11.186633063Z     batch.run()
2016-12-02T12:27:11.186665968Z   File "/usr/local/lib/python2.7/dist-packages/nidaba/nidaba.py", line 709, in run
2016-12-02T12:27:11.186997846Z     return super(SimpleBatch, self).run()
2016-12-02T12:27:11.187035438Z   File "/usr/local/lib/python2.7/dist-packages/nidaba/nidaba.py", line 495, in run
2016-12-02T12:27:11.187189526Z     [x.apply_async() for x in chains]
2016-12-02T12:27:11.187221471Z   File "/usr/local/lib/python2.7/dist-packages/celery/canvas.py", line 987, in apply_async
2016-12-02T12:27:11.187746747Z     args=args, kwargs=kwargs, **options))
2016-12-02T12:27:11.187772406Z   File "/usr/local/lib/python2.7/dist-packages/celery/canvas.py", line 1063, in _apply_tasks
2016-12-02T12:27:11.187896442Z     **options)
2016-12-02T12:27:11.187924058Z   File "/usr/local/lib/python2.7/dist-packages/celery/canvas.py", line 567, in apply_async
2016-12-02T12:27:11.188001622Z     dict(self.options, **options) if options else self.options))
2016-12-02T12:27:11.188019953Z   File "/usr/local/lib/python2.7/dist-packages/celery/canvas.py", line 597, in run
2016-12-02T12:27:11.188133949Z     first_task.apply_async(**options)
2016-12-02T12:27:11.188156432Z   File "/usr/local/lib/python2.7/dist-packages/celery/canvas.py", line 221, in apply_async
2016-12-02T12:27:11.188205732Z     return _apply(args, kwargs, **options)
2016-12-02T12:27:11.188224311Z   File "/usr/local/lib/python2.7/dist-packages/celery/app/task.py", line 518, in apply_async
2016-12-02T12:27:11.188613499Z     check_arguments(*(args or ()), **(kwargs or {}))
2016-12-02T12:27:11.188682083Z TypeError: rgb_to_gray() got an unexpected keyword argument 'batch_id'
```